### PR TITLE
Fix range implementation for nat

### DIFF
--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -94,10 +94,12 @@ snoc xs x = xs ++ (singleton x)
 
 public export
 unsnoc : (xs : List1 a) -> (List a, a)
-unsnoc (h ::: Nil)       = (Nil, h)
-unsnoc (h ::: (x :: xs)) =
-  let (ini,lst) = unsnoc (x ::: xs)
-   in (h :: ini, lst)
+unsnoc (x ::: xs) = go x xs where
+
+  go : (x : a) -> (xs : List a) -> (List a, a)
+  go x [] = ([], x)
+  go x (y :: ys) = let (ini,lst) = go y ys
+                   in (x :: ini, lst)
 
 ------------------------------------------------------------------------
 -- Reverse

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -820,7 +820,7 @@ Range Nat where
     EQ => pure x
     GT => assert_total $ takeUntil (<= y) (countFrom x (\n => minus n 1))
   rangeFromThenTo x y z = case compare x y of
-    LT => if z > x
+    LT => if z >= x
              then assert_total $ takeBefore (> z) (countFrom x (plus (minus y x)))
              else Nil
     EQ => if x == z then pure x else Nil

--- a/src/Core/Termination.idr
+++ b/src/Core/Termination.idr
@@ -383,13 +383,15 @@ mutual
            let fn = fullname gdef
            log "totality.termination.sizechange" 10 $ "Looking under " ++ show !(toFullNames fn)
            aSmaller <- resolved (gamma defs) (NS builtinNS (UN "assert_smaller"))
-           cond [(fn == NS builtinNS (UN "assert_total"), pure []),
-              (caseFn fn,
-                  do mps <- getCasePats defs fn pats args
-                     case mps of
-                          Nothing => pure Prelude.Nil
-                          Just ps => do scs <- traverse (findInCase defs g) ps
-                                        pure (concat scs))]
+           cond [(fn == NS builtinNS (UN "assert_total"), pure [])
+              -- #1782: this breaks totality!
+              -- ,(caseFn fn,
+              --     do mps <- getCasePats defs fn pats args
+              --        case mps of
+              --             Nothing => pure Prelude.Nil
+              --             Just ps => do scs <- traverse (findInCase defs g) ps
+              --                           pure (concat scs))
+              ]
               (do scs <- traverse (findSC defs env g pats) args
                   pure ([MkSCCall fn
                            (expandToArity arity

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -334,8 +334,18 @@ mutual
          pure $ Implicit fc False
   desugarB side ps (PMultiline fc indent lines)
       = addFromString fc !(expandString side ps fc !(trimMultiline fc indent lines))
+
+  -- We only add `fromString` if we are looking at a plain string literal.
+  -- Interpolated string literals don't have a `fromString` call since they
+  -- are always concatenated with other strings and therefore can never use
+  -- another `fromString` implementation that differs from `id`.
+  desugarB side ps (PString fc [])
+      = addFromString fc (IPrimVal fc (Str ""))
+  desugarB side ps (PString fc [StrLiteral fc' str])
+      = addFromString fc (IPrimVal fc' (Str str))
   desugarB side ps (PString fc strs)
-      = addFromString fc !(expandString side ps fc strs)
+      = expandString side ps fc strs
+
   desugarB side ps (PDoBlock fc ns block)
       = expandDo side ps fc ns block
   desugarB side ps (PBang fc term)

--- a/src/Libraries/Data/List1.idr
+++ b/src/Libraries/Data/List1.idr
@@ -6,9 +6,12 @@ import Data.List1
 
 -- TODO: Remove this, once Data.List1.unsnoc from base is available
 --       to the compiler
+
 export
 unsnoc : (xs : List1 a) -> (List a, a)
-unsnoc (h ::: Nil)       = (Nil, h)
-unsnoc (h ::: (x :: xs)) =
-  let (ini,lst) = Libraries.Data.List1.unsnoc (x ::: xs)
-   in (h :: ini, lst)
+unsnoc (x ::: xs) = go x xs where
+
+  go : (x : a) -> (xs : List a) -> (List a, a)
+  go x [] = ([], x)
+  go x (y :: ys) = let (ini,lst) = go y ys
+                   in (x :: ini, lst)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -171,7 +171,8 @@ idrisTestsTotality = MkTestPool "Totality checking" [] Nothing
       ["positivity001", "positivity002", "positivity003", "positivity004",
        -- Totality checking
        "total001", "total002", "total003", "total004", "total005",
-       "total006", "total007", "total008", "total009", "total010"
+       "total006", "total007", "total008", "total009", "total010",
+       "total011"
       ]
 
 idrisTests : TestPool

--- a/tests/idris2/total011/Issue1460.idr
+++ b/tests/idris2/total011/Issue1460.idr
@@ -1,0 +1,6 @@
+%default total
+
+nonproductive : Stream a -> (Stream a, ())
+nonproductive (x :: xs) =
+  case nonproductive xs of
+    (xs, ()) => (xs, ())

--- a/tests/idris2/total011/Issue1782.idr
+++ b/tests/idris2/total011/Issue1782.idr
@@ -1,0 +1,11 @@
+total
+notHack : Nat -> (Nat, Nat)
+notHack Z = (Z, Z)
+notHack (S n) = let (baz1, baz2) = notHack n
+                in (baz2, S baz1)
+
+
+total
+hack : Nat -> (Void, Void)
+hack n = let (baz1, baz2) = hack n
+         in (baz1, baz2)

--- a/tests/idris2/total011/expected
+++ b/tests/idris2/total011/expected
@@ -1,0 +1,16 @@
+1/1: Building Issue1782 (Issue1782.idr)
+Error: hack is not total, possibly not terminating due to recursive path Main.hack -> Main.hack
+
+Issue1782:8:1--9:27
+ 8 | total
+ 9 | hack : Nat -> (Void, Void)
+
+1/1: Building Issue1460 (Issue1460.idr)
+Error: nonproductive is not total, possibly not terminating due to recursive path Main.nonproductive -> Main.nonproductive -> Main.nonproductive
+
+Issue1460:3:1--3:43
+ 1 | %default total
+ 2 | 
+ 3 | nonproductive : Stream a -> (Stream a, ())
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/idris2/total011/run
+++ b/tests/idris2/total011/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 Issue1782.idr --check
+$1 --no-color --console-width 0 Issue1460.idr --check

--- a/tests/prelude/nat001/expected
+++ b/tests/prelude/nat001/expected
@@ -1,0 +1,1 @@
+1/1: Building nats (nats.idr)

--- a/tests/prelude/nat001/nats.idr
+++ b/tests/prelude/nat001/nats.idr
@@ -1,0 +1,36 @@
+nats : List Nat -> List Nat
+nats = the (List Nat)
+
+singletonRange : nats [1..1] = nats [1]
+singletonRange = Refl
+
+basicIncreasingRange : nats [1..3] = nats [1, 2 , 3]
+basicIncreasingRange = Refl
+
+basicDecreasingRange : nats [3..1] = nats [3, 2, 1]
+basicDecreasingRange = Refl
+
+
+increasingRangeWithStep : nats [3, 5..11] = nats [3, 5, 7, 9, 11]
+increasingRangeWithStep = Refl
+
+increaingRangeWithStepEmpty : nats [3, 5..1] = nats []
+increaingRangeWithStepEmpty = Refl
+
+singletonRangeWithStep : nats [3, 4..3] = nats [3]
+singletonRangeWithStep = Refl
+
+zeroStepEmptyList : nats [3, 3..5] = nats []
+zeroStepEmptyList = Refl
+
+zeroStepWhenBoundEqual : nats [1, 1..1] = nats [1]
+zeroStepWhenBoundEqual = Refl
+
+decreasingRanngeWithStep : nats [11, 8..1] = nats [11, 8, 5, 2]
+decreasingRanngeWithStep = Refl
+
+decreasingRangeWithStepEmpty : nats [9, 8..10] = nats []
+decreasingRangeWithStepEmpty = Refl
+
+decreasingSingletonRangeWithStep : nats [9, 8..9] = nats [9]
+decreasingSingletonRangeWithStep = Refl

--- a/tests/prelude/nat001/run
+++ b/tests/prelude/nat001/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --check nats.idr


### PR DESCRIPTION
The lists produced by `Range` instance for `Nat` differ from those for `Integer`, creating a confusing inconsistency:
```
Main> rangeFromThenTo (the Nat 2) 3 2
[]
Main> rangeFromThenTo (the Integer 2) 3 2
[2]
```
This is fixed by changing `Nat` instance to match the behaviour for `Integer`. Also some tests for `Nat` ranges are added.